### PR TITLE
fix: use dedicated token to push the generated docs

### DIFF
--- a/.github/workflows/build_docs.yaml
+++ b/.github/workflows/build_docs.yaml
@@ -8,6 +8,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.DOCS_TOKEN }}
       - name: build docs
         run: make docs
       - name: update docs


### PR DESCRIPTION
#### What's being changed?
Using a dedicated token to push the generated docs

#### Is this PR related to an existing issue?
No

#### Check off the following:

- [x] This PR follows the CONTRIBUTION.md guidelines
- [x] I have self-reviewed my changes before submitting the PR
