### PR TITLE
fix: remove policies from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,8 +28,6 @@ docs/_site
 docs/.jekyll-cache/
 docs/Gemfile
 docs/Gemfile.lock
-docs/policies
-docs/policies/**
 generated-docs.yaml
 .DS_Store
 docs/.DS_Store


### PR DESCRIPTION
#### What's being changed?
Removed `docs/policies` from .gitignore to make sure Github pages are updated

#### Check off the following:

- [x] This PR follows the CONTRIBUTION.md guidelines
- [x] I have self-reviewed my changes before submitting the PR
