### PR TITLE
fix: const can not be updated in compile time

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -2,7 +2,7 @@ package version
 
 import "fmt"
 
-const (
+var (
 	/* Note: name, version and commit are injected during CI. */
 	Name    = "legitify"
 	Version = "na"


### PR DESCRIPTION


#### What's being changed?
Changing version from const to var so it can be mutated in compile time.

#### Is this PR related to an existing issue?

fixes #25 

#### Check off the following:

- [X] This PR follows the CONTRIBUTION.md guidelines
- [X] I have self-reviewed my changes before submitting the PR
