### PR TITLE
feat: Added support for GitHub Enterprise instances (#10).

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,14 @@ GITHUB_TOKEN=<your_token> legitify analyze --org org1,org2 --namespaces organiza
 ```
 The above command will test organization and member policies against org1 and org2.
 
+## GitHub Enterprise Support
+You can run legitify against a GitHub Enterprise instance if you set the endpoint URL in the environment variable ``GITHUB_ENDPOINT``:
+
+```sh
+export GITHUB_ENDPOINT="https://github.example.com/"
+GITHUB_TOKEN=<your_token> legitify analyze --org org1,org2 --namespaces organization,member
+```
+
 ## Namespaces
 Namespaces in legitify are resources that are collected and run against the policies.
 Currently, the following namespaces are supported:

--- a/cmd/analyze.go
+++ b/cmd/analyze.go
@@ -3,12 +3,13 @@ package cmd
 import (
 	"context"
 	"fmt"
-	"github.com/Legit-Labs/legitify/cmd/common_options"
-	"github.com/Legit-Labs/legitify/internal/analyzers/skippers"
-	"github.com/Legit-Labs/legitify/internal/common/types"
 	"log"
 	"os"
 	"strings"
+
+	"github.com/Legit-Labs/legitify/cmd/common_options"
+	"github.com/Legit-Labs/legitify/internal/analyzers/skippers"
+	"github.com/Legit-Labs/legitify/internal/common/types"
 
 	"github.com/Legit-Labs/legitify/internal/opa"
 
@@ -186,6 +187,10 @@ func executeAnalyzeCommand(cmd *cobra.Command, _args []string) error {
 		stdErrLog.Printf("Note: to get the OpenSSF scorecard results for the organization repositories use the --scorecard option\n\n")
 	}
 
+	githubEndpoint := viper.GetString(common_options.EnvGitHubEndpoint)
+	if githubEndpoint != "" {
+		stdErrLog.Printf("Using Github Enterprise Endpoint: %s\n\n", githubEndpoint)
+	}
 	githubClient, err := github.NewClient(ctx, analyzeArgs.Token,
 		analyzeArgs.Organizations, len(parsedRepositories) == 0)
 

--- a/cmd/common_options/common_options.go
+++ b/cmd/common_options/common_options.go
@@ -7,5 +7,6 @@ const (
 )
 
 const (
-	EnvToken = "github_token"
+	EnvToken          = "github_token"
+	EnvGitHubEndpoint = "github_endpoint"
 )

--- a/internal/clients/github/client.go
+++ b/internal/clients/github/client.go
@@ -56,8 +56,12 @@ func IsTokenValid(token string) error {
 	return nil
 }
 
-func getGitHubEnterpriseGraphURL() string {
+func getGitHubGraphURL() string {
 	githubEndpoint := viper.GetString(common_options.EnvGitHubEndpoint)
+	if githubEndpoint == "" {
+		return "https://api.github.com/graphql"
+	}
+	
 	githubEndpoint = strings.TrimRight(githubEndpoint, "/")
 	return githubEndpoint + "/api/graphql"
 }
@@ -95,7 +99,7 @@ func NewClient(ctx context.Context, token string, org []string, fillCache bool) 
 	if githubEndpoint == "" {
 		graphQLClient = githubv4.NewClient(&clientWithAcceptHeader)
 	} else {
-		graphQLClient = githubv4.NewEnterpriseClient(getGitHubEnterpriseGraphURL(), &clientWithAcceptHeader)
+		graphQLClient = githubv4.NewEnterpriseClient(getGitHubGraphURL(), &clientWithAcceptHeader)
 	}
 
 	client := &client{
@@ -243,12 +247,7 @@ func (c *client) getRole(orgName string) (permissions.OrganizationRole, error) {
 }
 
 func (c *client) collectTokenScopes() (permissions.TokenScopes, error) {
-	graphQLUrl := "https://api.github.com/graphql"
-	githubEndpoint := viper.GetString(common_options.EnvGitHubEndpoint)
-	if githubEndpoint != "" {
-		graphQLUrl = getGitHubEnterpriseGraphURL()
-	}
-
+	graphQLUrl := getGitHubGraphURL()
 	var buf bytes.Buffer
 	resp, err := c.rawClient.Post(graphQLUrl, "application/json", &buf)
 	if err != nil {

--- a/internal/clients/github/client.go
+++ b/internal/clients/github/client.go
@@ -9,8 +9,10 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/Legit-Labs/legitify/cmd/common_options"
 	githubcollected "github.com/Legit-Labs/legitify/internal/collected/github"
 	"github.com/Legit-Labs/legitify/internal/common/permissions"
+	"github.com/spf13/viper"
 
 	"github.com/google/go-github/v44/github"
 	gh "github.com/google/go-github/v44/github"
@@ -54,6 +56,12 @@ func IsTokenValid(token string) error {
 	return nil
 }
 
+func getGitHubEnterpriseGraphURL() string {
+	githubEndpoint := viper.GetString(common_options.EnvGitHubEndpoint)
+	githubEndpoint = strings.TrimRight(githubEndpoint, "/")
+	return githubEndpoint + "/api/graphql"
+}
+
 func isBadRequest(err error) bool {
 	return err.Error() == "Bad credentials"
 }
@@ -68,11 +76,27 @@ func NewClient(ctx context.Context, token string, org []string, fillCache bool) 
 	)
 
 	tc := oauth2.NewClient(ctx, ts)
-	ghClient := gh.NewClient(tc)
+	var ghClient *gh.Client
+	githubEndpoint := viper.GetString(common_options.EnvGitHubEndpoint)
+	if githubEndpoint == "" {
+		ghClient = gh.NewClient(tc)
+	} else {
+		var err error
+		ghClient, err = gh.NewEnterpriseClient(githubEndpoint, githubEndpoint, tc)
+		if err != nil {
+			return nil, err
+		}
+	}
 
 	acceptHeader := experimentalApiAcceptHeader
 	clientWithAcceptHeader := NewClientWithAcceptHeader(tc.Transport, &acceptHeader)
-	graphQLClient := githubv4.NewClient(&clientWithAcceptHeader)
+
+	var graphQLClient *githubv4.Client
+	if githubEndpoint == "" {
+		graphQLClient = githubv4.NewClient(&clientWithAcceptHeader)
+	} else {
+		graphQLClient = githubv4.NewEnterpriseClient(getGitHubEnterpriseGraphURL(), &clientWithAcceptHeader)
+	}
 
 	client := &client{
 		client:        ghClient,
@@ -220,6 +244,11 @@ func (c *client) getRole(orgName string) (permissions.OrganizationRole, error) {
 
 func (c *client) collectTokenScopes() (permissions.TokenScopes, error) {
 	graphQLUrl := "https://api.github.com/graphql"
+	githubEndpoint := viper.GetString(common_options.EnvGitHubEndpoint)
+	if githubEndpoint != "" {
+		graphQLUrl = getGitHubEnterpriseGraphURL()
+	}
+
 	var buf bytes.Buffer
 	resp, err := c.rawClient.Post(graphQLUrl, "application/json", &buf)
 	if err != nil {


### PR DESCRIPTION
<!--
Thank you for contributing to this project! Please fill out the information below to help us review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can best triage your pull request.

See our [CONTRIBUTING.md](/main/CONTRIBUTING.md) for information on how to contribute.

Thanks again!
-->

This pull request adds support for GitHub Enterprise instance (#10).

#### What's being changed?

You can run legitify against a GitHub Enterprise instance if you set the endpoint URL in the environment variable ``GITHUB_ENDPOINT``:

```sh
export GITHUB_ENDPOINT="https://github.example.com/"
GITHUB_TOKEN=<your_token> legitify analyze --org org1,org2 --namespaces organization,member
```

#### Is this PR related to an existing issue?

resolves #10 

#### Check off the following:

- [x] This PR follows the CONTRIBUTION.md guidelines
- [x] I have self-reviewed my changes before submitting the PR
