### PR TITLE
fix: lazy fill cache to avoid delays before printing starts

### DIFF
--- a/cmd/analyze.go
+++ b/cmd/analyze.go
@@ -165,7 +165,7 @@ func executeAnalyzeCommand(cmd *cobra.Command, _args []string) error {
 	}
 
 	githubClient, err := github.NewClient(ctx, analyzeArgs.Token, analyzeArgs.Endpoint,
-		analyzeArgs.Organizations, len(parsedRepositories) == 0)
+		analyzeArgs.Organizations, false)
 
 	if err != nil {
 		return err


### PR DESCRIPTION
#### What's being changed?
Avoid cache initialization in NewClient.
Running with big organization and GH latency may result in a long load-time before the initial "collecting metadata" print.

#### Is this PR related to an existing issue?
No

#### Check off the following:

- [X] This PR follows the CONTRIBUTION.md guidelines
- [X] I have self-reviewed my changes before submitting the PR
