### PR TITLE
fix: Remove duplicated numbering in the remediationSteps

### DIFF
--- a/policies/github/actions.rego
+++ b/policies/github/actions.rego
@@ -48,12 +48,12 @@ all_github_actions_are_allowed {
 # custom:
 #   requiredEnrichers: [organizationId]
 #   remediationSteps:
-#     - 1. Make sure you have admin permissions
-#     - 2. Go to the org's settings page
-#     - 3. Enter "Actions - General" tab
-#     - 4. Under 'Workflow permissions'
-#     - 5. Select 'Read repository contents permission'
-#     - 6. Click 'Save'
+#     - Make sure you have admin permissions
+#     - Go to the org's settings page
+#     - Enter "Actions - General" tab
+#     - Under 'Workflow permissions'
+#     - Select 'Read repository contents permission'
+#     - Click 'Save'
 #   severity: MEDIUM
 #   requiredScopes: [admin:org]
 #   threat: In case of token compromise (due to a vulnerability or malicious third-party GitHub actions), an attacker can use this token to sabotage various assets in your CI/CD pipeline, such as packages, pull-requests, deployments, and more.
@@ -69,12 +69,12 @@ token_default_permissions_is_read_write {
 # custom:
 #   requiredEnrichers: [organizationId]
 #   remediationSteps:
-#     - 1. Make sure you have admin permissions
-#     - 2. Go to the org's settings page
-#     - 3. Enter "Actions - General" tab
-#     - 4. Under 'Workflow permissions'
-#     - 5. Uncheck 'Allow GitHub actions to create and approve pull requests.
-#     - 6. Click 'Save'
+#     - Make sure you have admin permissions
+#     - Go to the org's settings page
+#     - Enter "Actions - General" tab
+#     - Under 'Workflow permissions'
+#     - Uncheck 'Allow GitHub actions to create and approve pull requests.
+#     - Click 'Save'
 #   severity: HIGH
 #   requiredScopes: [admin:org]
 #   threat: Attackers can exploit this misconfiguration to bypass code-review restrictions by creating a workflow that approves their own pull request and then merging the pull request without anyone noticing, introducing malicious code that would go straight ahead to production.

--- a/policies/github/repository.rego
+++ b/policies/github/repository.rego
@@ -348,12 +348,12 @@ scorecard_score_too_low {
 # custom:
 #   requiredEnrichers: [organizationId]
 #   remediationSteps:
-#     - 1. Make sure you have admin permissions
-#     - 2. Go to the org's settings page
-#     - 3. Enter "Actions - General" tab
-#     - 4. Under 'Workflow permissions'
-#     - 5. Select 'Read repository contents permission'
-#     - 6. Click 'Save'
+#     - Make sure you have admin permissions
+#     - Go to the org's settings page
+#     - Enter "Actions - General" tab
+#     - Under 'Workflow permissions'
+#     - Select 'Read repository contents permission'
+#     - Click 'Save'
 #   severity: MEDIUM
 #   requiredScopes: [admin:org]
 #   threat: In case of token compromise (due to a vulnerability or malicious third-party GitHub actions), an attacker can use this token to sabotage various assets in your CI/CD pipeline, such as packages, pull-requests, deployments, and more.
@@ -369,12 +369,12 @@ token_default_permissions_is_read_write {
 # custom:
 #   requiredEnrichers: [organizationId]
 #   remediationSteps:
-#     - 1. Make sure you have admin permissions
-#     - 2. Go to the org's settings page
-#     - 3. Enter "Actions - General" tab
-#     - 4. Under 'Workflow permissions'
-#     - 5. Uncheck 'Allow GitHub actions to create and approve pull requests.
-#     - 6. Click 'Save'
+#     - Make sure you have admin permissions
+#     - Go to the org's settings page
+#     - Enter "Actions - General" tab
+#     - Under 'Workflow permissions'
+#     - Uncheck 'Allow GitHub actions to create and approve pull requests.
+#     - Click 'Save'
 #   severity: HIGH
 #   requiredScopes: [admin:org]
 #   threat: Attackers can exploit this misconfiguration to bypass code-review restrictions by creating a workflow that approves their own pull request and then merging the pull request without anyone noticing, introducing malicious code that would go straight ahead to production.


### PR DESCRIPTION
<!--
Thank you for contributing to this project! Please fill out the information below to help us review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can best triage your pull request.

See our [CONTRIBUTING.md](/main/CONTRIBUTING.md) for information on how to contribute.

Thanks again!
-->

#### What's being changed?
<!-- Consider sharing artifacts of the changes, such as code snippets, GIFs or screenshots; whatever shares the most context. -->
Hi 👋 . This PR tries to remove the duplicated numbering shown as part of the `remediationSteps` (ex. `1. 1. Make sure you have admin permissions`).

Some `.rego` file definitions include explicit numbering (`1.`), but I believe these numbers are automatically assigned from the array definition (other rules don't have explicit numbering).

**Before**

```
$ go run main.go analyze --org sample-org-1 --namespace repository

...

Workflows Are Allowed To Approve Pull Requests
----------------------------------------------
  Your default GitHub Actions configuration allows for workflows to approve pull requests. This could allow users to bypass code-review restrictions.
  Policy Name: data.repository.actions_can_approve_pull_requests
  Namespace: repository
  Severity: HIGH
  Remediation Steps:
    1. 1. Make sure you have admin permissions
    2. 2. Go to the org's settings page
    3. 3. Enter "Actions - General" tab
    4. 4. Under 'Workflow permissions'
    5. 5. Uncheck 'Allow GitHub actions to create and approve pull requests.
    6. 6. Click 'Save'
```

**After**

```
$ go run main.go analyze --org sample-org-1 --namespace repository

...

Workflows Are Allowed To Approve Pull Requests
----------------------------------------------
  Your default GitHub Actions configuration allows for workflows to approve pull requests. This could allow users to bypass code-review restrictions.
  Policy Name: data.repository.actions_can_approve_pull_requests
  Namespace: repository
  Severity: HIGH
  Remediation Steps:
    1. Make sure you have admin permissions
    2. Go to the org's settings page
    3. Enter "Actions - General" tab
    4. Under 'Workflow permissions'
    5. Uncheck 'Allow GitHub actions to create and approve pull requests.
    6. Click 'Save'
```

#### Is this PR related to an existing issue?
<!--
- If there's an existing issue for your change, please link to it.
- If there's _no_ existing issue, please consider opening one first: https://github.com/legit-labs/legitify/issues/new/choose. -->

#### Check off the following:

- [x] This PR follows the CONTRIBUTION.md guidelines
- [x] I have self-reviewed my changes before submitting the PR
