### PR TITLE
fix: removed the 'blocks_creations' field

### DIFF
--- a/internal/collected/github/repository.go
+++ b/internal/collected/github/repository.go
@@ -43,7 +43,6 @@ type GitHubQLRepository struct {
 type GitHubQLBranchProtectionRule struct {
 	AllowsDeletions                *bool `json:"allows_deletions,omitempty"`
 	AllowsForcePushes              *bool `json:"allows_force_pushes,omitempty"`
-	BlocksCreations                *bool `json:"blocks_creations,omitempty"`
 	DismissesStaleReviews          *bool `json:"dismisses_stale_reviews,omitempty"`
 	IsAdminEnforced                *bool `json:"is_admin_enforced,omitempty"`
 	RequiredApprovingReviewCount   *int  `json:"required_approving_review_count,omitempty"`


### PR DESCRIPTION
#### What's being changed?
Removed the 'block_creations' field from the graphQL request since it's not supported in old GH versions, and we don't have a policy for it

#### Is this PR related to an existing issue?
https://github.com/Legit-Labs/legitify/issues/42

#### Check off the following:

- [X] This PR follows the CONTRIBUTION.md guidelines
- [X] I have self-reviewed my changes before submitting the PR
