### PR TITLE
fix: progress bar without terminal

### DIFF
--- a/cmd/analyze_executor.go
+++ b/cmd/analyze_executor.go
@@ -1,13 +1,14 @@
 package cmd
 
 import (
+	"log"
+	"os"
+
 	"github.com/Legit-Labs/legitify/cmd/progressbar"
 	"github.com/Legit-Labs/legitify/internal/analyzers"
 	"github.com/Legit-Labs/legitify/internal/collectors/collectors_manager"
 	"github.com/Legit-Labs/legitify/internal/enricher"
 	"github.com/Legit-Labs/legitify/internal/outputer"
-	"log"
-	"os"
 )
 
 type analyzeExecutor struct {

--- a/cmd/color.go
+++ b/cmd/color.go
@@ -2,10 +2,9 @@ package cmd
 
 import (
 	"fmt"
-	"os"
 
+	"github.com/Legit-Labs/legitify/cmd/tty"
 	"github.com/fatih/color"
-	"github.com/mattn/go-isatty"
 )
 
 const (
@@ -19,14 +18,6 @@ func ColorOptions() []string {
 	return []string{colorAuto, colorAlways, colorNone}
 }
 
-func isTty() bool {
-	// Inspired by the color package:
-	// color package decides whether or not to use colors based on stdout,
-	// but it does it on import time, which is too early for us.
-	return os.Getenv("TERM") != "dumb" &&
-		(isatty.IsTerminal(os.Stdout.Fd()) || isatty.IsCygwinTerminal(os.Stdout.Fd()))
-}
-
 func InitColorPackage(colorWhen string) error {
 	switch colorWhen {
 	case colorAlways:
@@ -34,7 +25,7 @@ func InitColorPackage(colorWhen string) error {
 	case colorNone:
 		color.NoColor = true
 	case colorAuto:
-		color.NoColor = !isTty()
+		color.NoColor = !tty.IsStdoutTty()
 	default:
 		return fmt.Errorf("invalid color option: %s", colorWhen)
 	}

--- a/cmd/tty/tty.go
+++ b/cmd/tty/tty.go
@@ -1,0 +1,22 @@
+package tty
+
+import (
+	"os"
+
+	"github.com/mattn/go-isatty"
+)
+
+func IsStdoutTty() bool {
+	return IsTty(os.Stdout)
+}
+func IsStderrTty() bool {
+	return IsTty(os.Stderr)
+}
+
+func IsTty(file *os.File) bool {
+	// Inspired by the color package:
+	// color package decides whether or not to use colors based on stdout,
+	// but it does it on import time, which is too early for us.
+	return os.Getenv("TERM") != "dumb" &&
+		(isatty.IsTerminal(file.Fd()) || isatty.IsCygwinTerminal(file.Fd()))
+}

--- a/internal/collectors/collectors_manager/collectors_manager.go
+++ b/internal/collectors/collectors_manager/collectors_manager.go
@@ -68,6 +68,7 @@ func (m *manager) Collect() CollectorChannels {
 
 		gw := group_waiter.New()
 		for _, c := range m.collectors {
+			c := c
 			collectionChannels := c.Collect()
 
 			gw.Do(func() {

--- a/internal/outputer/scheme/scheme.go
+++ b/internal/outputer/scheme/scheme.go
@@ -119,6 +119,7 @@ func policiesSortByNamespaceLess(i, j *orderedmap.Pair) bool {
 		namespace.Actions:      1,
 		namespace.Member:       2,
 		namespace.Repository:   3,
+		namespace.RunnerGroup:  4,
 	}
 
 	iNamespace := i.Value().(OutputData).PolicyInfo.Namespace


### PR DESCRIPTION
#### What's being changed?
- disable progress bar when stderr is not a terminal
- bugfix: missing runner_group in output scheme priority map
- bugfix: reporting progress.Finished correctly for all bars 

#### Is this PR related to an existing issue?
no

#### Check off the following:

- [x] This PR follows the CONTRIBUTION.md guidelines
- [x] I have self-reviewed my changes before submitting the PR
