### PR TITLE
docs: Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,14 +8,14 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Legit-Labs/legitify-github-action.git"
+    "url": "git+https://github.com/Legit-Labs/legitify.git"
   },
   "author": "",
   "license": "ISC",
   "bugs": {
-    "url": "https://github.com/Legit-Labs/legitify-github-action/issues"
+    "url": "https://github.com/Legit-Labs/legitify/issues"
   },
-  "homepage": "https://github.com/Legit-Labs/legitify-github-action#readme",
+  "homepage": "https://github.com/Legit-Labs/legitify#readme",
   "dependencies": {
     "@actions/artifact": "^1.1.0",
     "@actions/core": "^1.10.0",


### PR DESCRIPTION
Fixing the links in the package.json. Seems like the action repo was recreated and the new links are the ones that where intended.