### PR TITLE
fix: clean and ignore generated docs folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,8 @@ error.log
 docs/_site
 docs/.jekyll-cache/
 docs/Gemfile
+docs/github
+docs/gitlab
 docs/Gemfile.lock
 generated-docs.yaml
 .DS_Store

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,9 @@ build_and_install_deps: install_deps build
 
 clean:
 	rm -f "${BINARY_NAME}"
+	rm -rf docs/github
+	rm -rf docs/gitlab
+
 .PHONY: clean
 
 install:


### PR DESCRIPTION
<!--
Thank you for contributing to this project! Please fill out the information below to help us review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can best triage your pull request.

See our [CONTRIBUTING.md](/main/CONTRIBUTING.md) for information on how to contribute.

Thanks again!
-->

#### What's being changed?
- Git ignore the generated /docs (docs/github, docs/gitlab) folders 
- Delete the docs/gitlab and docs/github folders on running `make clean`

#### Is this PR related to an existing issue?
Issue #142


#### Check off the following:

- [ ] This PR follows the CONTRIBUTION.md guidelines
- [ x] I have self-reviewed my changes before submitting the PR
