### PR TITLE
fix: skip failing policies when scanning gitlab free groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,9 @@ export SERVER_URL="https://gitlab.example.com/"
 LEGITIFY_TOKEN=<your_token> legitify analyze --namespace organization --scm gitlab
 ```
 
+> **_NOTE:_**  For non-premium GitLab accounts some policies (such as branch protection policies) will be skipped
+
+
 ## Namespaces
 
 Namespaces in legitify are resources that are collected and run against the policies.

--- a/internal/collectors/gitlab/collection_context.go
+++ b/internal/collectors/gitlab/collection_context.go
@@ -6,20 +6,21 @@ import (
 )
 
 type collectionContext struct {
-	group *gitlab.Group
-	roles []permissions.Role
+	group     *gitlab.Group
+	roles     []permissions.Role
+	isPremium bool
 }
 
-func newCollectionContext(group *gitlab.Group, roles []permissions.Role) collectionContext {
+func newCollectionContext(group *gitlab.Group, roles []permissions.Role, isPremium bool) collectionContext {
 	return collectionContext{
-		group: group,
-		roles: roles,
+		group:     group,
+		roles:     roles,
+		isPremium: isPremium,
 	}
 }
 
 func (c collectionContext) Premium() bool {
-	// TODO: currently we don't know about GitLab policies that required premium account, need to update this once we do.
-	return true
+	return c.isPremium
 }
 
 func (c collectionContext) Roles() []permissions.Role {

--- a/internal/collectors/gitlab/group_collector.go
+++ b/internal/collectors/gitlab/group_collector.go
@@ -58,6 +58,8 @@ func (c *groupCollector) Collect() collectors.SubCollectorChannels {
 					return
 				}
 
+				isPremium := c.Client.IsGroupPremium(g)
+
 				hooks, err := c.Client.GroupHooks(fullGroup.ID)
 
 				if err != nil {
@@ -69,7 +71,8 @@ func (c *groupCollector) Collect() collectors.SubCollectorChannels {
 					Hooks: hooks,
 				}
 
-				c.CollectDataWithContext(entity, g.WebURL, newCollectionContext(g, []permissions.OrganizationRole{permissions.RepoRoleAdmin}))
+				c.CollectDataWithContext(entity, g.WebURL,
+					newCollectionContext(g, []permissions.OrganizationRole{permissions.RepoRoleAdmin}, isPremium))
 				c.CollectionChangeByOne()
 			})
 		}

--- a/internal/collectors/gitlab/group_collector.go
+++ b/internal/collectors/gitlab/group_collector.go
@@ -72,7 +72,7 @@ func (c *groupCollector) Collect() collectors.SubCollectorChannels {
 				}
 
 				c.CollectDataWithContext(entity, g.WebURL,
-					newCollectionContext(g, []permissions.OrganizationRole{permissions.RepoRoleAdmin}, isPremium))
+					newCollectionContext(g, []permissions.RepositoryRole{permissions.RepoRoleAdmin}, isPremium))
 				c.CollectionChangeByOne()
 			})
 		}

--- a/internal/collectors/gitlab/repository_collector.go
+++ b/internal/collectors/gitlab/repository_collector.go
@@ -88,7 +88,7 @@ func (rc *repositoryCollector) collectSpecific(repositories []types.RepositoryWi
 				isPremium := false
 				group, err := rc.Client.Group(r.Owner)
 				if err != nil {
-					log.Printf(err.Error())
+					log.Println(err.Error())
 				} else {
 					isPremium = rc.Client.IsGroupPremium(group)
 				}

--- a/internal/collectors/gitlab/repository_collector.go
+++ b/internal/collectors/gitlab/repository_collector.go
@@ -39,20 +39,20 @@ func (rc *repositoryCollector) CollectTotalEntities() int {
 		return len(repositories)
 	}
 
-	organizations, err := rc.Client.Organizations()
+	groups, err := rc.Client.Groups()
 	if err != nil {
-		log.Printf("failed to collect list of orgniazations to get repositories metadata %s", err)
+		log.Printf("failed to collect list of groups to get repositories metadata %s", err)
 		return 0
 	}
 
 	var total atomic.Int64
 	gw := group_waiter.New()
-	for _, org := range organizations {
-		org := org
+	for _, group := range groups {
+		group := group
 		gw.Do(func() {
-			_, resp, err := rc.Client.Client().Groups.ListGroupProjects(org.ID, &gitlab2.ListGroupProjectsOptions{})
+			_, resp, err := rc.Client.Client().Groups.ListGroupProjects(group.ID, &gitlab2.ListGroupProjectsOptions{})
 			if err != nil {
-				log.Printf("failed to collect metadata for repositories of group %s (%d): %s", org.Name, org.ID, err)
+				log.Printf("failed to collect metadata for repositories of group %s (%d): %s", group.Name, group.ID, err)
 			} else {
 				total.Add(int64(resp.TotalItems))
 			}
@@ -191,7 +191,7 @@ func (rc *repositoryCollector) collectAll() collectors.SubCollectorChannels {
 	return rc.WrappedCollection(func() {
 		groups, err := rc.Client.Groups()
 		if err != nil {
-			log.Printf("failed to collect list of orgniazations to get repositories  %s", err)
+			log.Printf("failed to collect list of groups to get repositories  %s", err)
 			return
 		}
 		gw := group_waiter.New()
@@ -238,7 +238,7 @@ func (rc *repositoryCollector) extendedCollection(completeProjectsList *gitlab2.
 		}
 	}
 
-	newContext := newCollectionContext(nil, []permissions.OrganizationRole{permissions.OrgRoleOwner},
+	newContext := newCollectionContext(nil, []permissions.Role{permissions.GroupRoleOwner},
 		isPremium)
 	rc.CollectDataWithContext(proj, proj.Links.Self, &newContext)
 	rc.CollectionChangeByOne()

--- a/internal/collectors/gitlab/user_collector.go
+++ b/internal/collectors/gitlab/user_collector.go
@@ -96,7 +96,7 @@ func (c *userCollector) collectGroupUsers(group *gitlab2.Group) {
 				User: u,
 			}
 			c.CollectDataWithContext(&entity, entity.CanonicalLink(),
-				newCollectionContext(nil, []permissions.OrganizationRole{permissions.OrgRoleOwner},
+				newCollectionContext(nil, []permissions.Role{permissions.GroupRoleOwner},
 					c.Client.IsGroupPremium(group)))
 			c.CollectionChangeByOne()
 		})

--- a/internal/collectors/gitlab/user_collector.go
+++ b/internal/collectors/gitlab/user_collector.go
@@ -96,7 +96,8 @@ func (c *userCollector) collectGroupUsers(group *gitlab2.Group) {
 				User: u,
 			}
 			c.CollectDataWithContext(&entity, entity.CanonicalLink(),
-				newCollectionContext(nil, []permissions.OrganizationRole{permissions.OrgRoleOwner}))
+				newCollectionContext(nil, []permissions.OrganizationRole{permissions.OrgRoleOwner},
+					c.Client.IsGroupPremium(group)))
 			c.CollectionChangeByOne()
 		})
 	}

--- a/internal/common/permissions/permissions.go
+++ b/internal/common/permissions/permissions.go
@@ -9,6 +9,13 @@ const (
 	OrgRoleMember = "MEMBER"
 )
 
+const (
+	GroupRoleNone Role = OrgRoleNone
+
+	GroupRoleOwner  = OrgRoleOwner
+	GroupRoleMember = OrgRoleMember
+)
+
 type RepositoryRole = string
 
 const (

--- a/policies/gitlab/repository.rego
+++ b/policies/gitlab/repository.rego
@@ -65,6 +65,7 @@ forking_allowed_for_repository = false {
 # custom:
 #   remediationSteps: [Make sure you have owner permissions, Go to the projects's settings -> Repository page, Enter "Protected branches" tab, select the default branch. Set the allowed to merge to "maintainers" and the allowed to push to "No one"]
 #   severity: MEDIUM
+#   prerequisites: [premium]
 #   threat: Any contributor with write access may push potentially dangerous code to this repository, making it easier to compromise and difficult to audit.
 default missing_default_branch_protection = true
 
@@ -80,6 +81,7 @@ missing_default_branch_protection = false {
 # custom:
 #   remediationSteps: [Make sure you have owner permissions, Go to the projects's settings -> Repository page, Enter "Protected branches" tab, select the default branch. Set the allowed to merge to "maintainers" and the allowed to push to "No one"]
 #   severity: MEDIUM
+#   prerequisites: [premium]
 #   threat: Rewriting project history can make it difficult to trace back when bugs or security issues were introduced, making them more difficult to remediate.
 default missing_default_branch_protection_force_push = true
 
@@ -98,6 +100,7 @@ missing_default_branch_protection_force_push = false {
 # custom:
 #   remediationSteps: [Make sure you have owner permissions, Go to the projects's settings -> Repository page, Enter "Protected branches" tab, select the default branch. Check the "Code owner approval"]
 #   severity: LOW
+#   prerequisites: [premium]
 #   threat: A pull request may be approved by any contributor with write access. Specifying specific code owners can ensure review is only done by individuals with the correct expertise required for the review of the changed files, potentially preventing bugs and security risks.
 default repository_require_code_owner_reviews_policy = true
 
@@ -160,6 +163,7 @@ no_conversation_resolution = false {
 # custom:
 #   remediationSteps: [Make sure you have owner permissions, Go to the projects's settings -> Repository page, Enter "Push Rules" tab. Set the "Reject unsigned commits" checkbox ]
 #   severity: LOW
+#   prerequisites: [premium]
 #   threat: A commit containing malicious code may be crafted by a malicious actor that has acquired write access to the repository to initiate a supply chain attack. Commit signing provides another layer of defense that can prevent this type of compromise.
 default no_signed_commits = true
 
@@ -175,6 +179,7 @@ no_signed_commits = false {
 # custom:
 #   remediationSteps: [Make sure you have admin permissions, Go to the repo's settings page, Enter "Merge Requests" tab, Under "Merge request approvals", Click "Add approval rule" on the default branch rule, Select "Approvals required" and enter at least 1 approvers", Select "Add approvers" and select the desired members, Click "Add approval rule"]
 #   severity: HIGH
+#   prerequisites: [premium]
 #   threat:
 #    - "Users can merge code without being reviewed which can lead to insecure code reaching the main branch and production."
 default code_review_not_required = true
@@ -190,6 +195,7 @@ code_review_not_required = false {
 # custom:
 #   remediationSteps: [Make sure you have admin permissions, Go to the repo's settings page, Enter "Merge Requests" tab, Under "Merge request approvals", Click "Add approval rule" on the default branch rule, Select "Approvals required" and enter at least 2 approvers", Select "Add approvers" and select the desired members, Click "Add approval rule"]
 #   severity: MEDIUM
+#   prerequisites: [premium]
 #   threat:
 #    - "Users can merge code without being reviewed which can lead to insecure code reaching the main branch and production."
 default code_review_by_two_members_not_required = true
@@ -220,6 +226,7 @@ repository_allows_review_requester_to_approve_their_own_request = false {
 # custom:
 #   remediationSteps: [Make sure you have admin permissions, Go to the repo's settings page, Enter "Merge Requests" tab, Under "Approval settings", Check "Prevent editing approval rules in merge requests", Click "Save Changes"]
 #   severity: MEDIUM
+#   prerequisites: [premium]
 #   threat:
 #    - "Users can merge code without being reviewed which can lead to insecure code reaching the main branch and production."
 default repository_allows_overriding_approvers = true
@@ -235,6 +242,7 @@ repository_allows_overriding_approvers = false {
 # custom:
 #   remediationSteps: [Make sure you have admin permissions, Go to the repo's settings page, Enter "Merge Requests" tab, Under "Approval settings", Check "Prevent approvals by users who add commits", Click "Save Changes"]
 #   severity: LOW
+#   prerequisites: [premium]
 #   threat:
 #    - "Users can merge code without being reviewed which can lead to insecure code reaching the main branch and production."
 default repository_allows_committer_approvals_policy = true
@@ -250,6 +258,7 @@ repository_allows_committer_approvals_policy = false {
 # custom:
 #   remediationSteps: [Make sure you have admin permissions, Go to the repo's settings page, Enter "Merge Requests" tab, Under "Approval settings", Check "Remove all approvals", Click "Save Changes"]
 #   severity: LOW
+#   prerequisites: [premium]
 #   threat: Buggy or insecure code may be committed after approval and will reach the main branch without review. Alternatively, an attacker can attempt a just-in-time attack to introduce dangerous code just before merge.
 default repository_dismiss_stale_reviews = true
 


### PR DESCRIPTION
<!--
Thank you for contributing to this project! Please fill out the information below to help us review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can best triage your pull request.

See our [CONTRIBUTING.md](/main/CONTRIBUTING.md) for information on how to contribute.

Thanks again!
-->

#### What's being changed?
Skip failing repository policies when scanning gitlab free groups


#### Is this PR related to an existing issue?
<!--
- If there's an existing issue for your change, please link to it.
- If there's _no_ existing issue, please consider opening one first: https://github.com/legit-labs/legitify/issues/new/choose. -->
https://github.com/Legit-Labs/legitify/issues/208

#### Check off the following:

- [X] This PR follows the CONTRIBUTION.md guidelines
- [X] I have self-reviewed my changes before submitting the PR
