### PR TITLE
feat: add parameter to control gpt model choice

### DIFF
--- a/cmd/analyze_gpt.go
+++ b/cmd/analyze_gpt.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	gogpt "github.com/sashabaranov/go-openai"
 
 	"github.com/Legit-Labs/legitify/internal/common/namespace"
 	"github.com/Legit-Labs/legitify/internal/common/scm_type"
@@ -16,6 +17,7 @@ func init() {
 var analyzeGptArgs args
 
 const argOpenAiToken = "openai_token"
+const argOpenAiGptModel = "model"
 
 func newAnalyzeGptCommand() *cobra.Command {
 	analyzeCmd := &cobra.Command{
@@ -32,6 +34,7 @@ func newAnalyzeGptCommand() *cobra.Command {
 	flags.StringSliceVarP(&analyzeGptArgs.Organizations, argOrg, "", nil, "specific organizations to collect")
 	flags.StringSliceVarP(&analyzeGptArgs.Repositories, argRepository, "", nil, "specific repositories to collect (--repo owner/repo_name (e.g. ossf/scorecard)")
 	flags.StringVarP(&analyzeGptArgs.OpenAIToken, argOpenAiToken, "", "", "token to authenticate with openai API")
+	flags.StringVarP(&analyzeGptArgs.OpenAIGptModel, argOpenAiGptModel, "", gogpt.GPT3TextDavinci003, "gpt-model to use")
 	viper.AutomaticEnv()
 
 	return analyzeCmd

--- a/cmd/common_args.go
+++ b/cmd/common_args.go
@@ -20,6 +20,7 @@ import (
 type args struct {
 	Token                      string
 	OpenAIToken                string
+	OpenAIGptModel             string
 	Endpoint                   string
 	ScmType                    scm_type.ScmType
 	Organizations              []string

--- a/cmd/common_providers.go
+++ b/cmd/common_providers.go
@@ -92,5 +92,5 @@ func provideContext(client Client, args *args) (context.Context, error) {
 }
 
 func provideGPTAnalyzer(context context.Context, args *args) *gpt.Analyzer {
-	return gpt.NewAnalyzer(context, args.OpenAIToken)
+	return gpt.NewAnalyzer(context, args.OpenAIToken, args.OpenAIGptModel)
 }

--- a/internal/gpt/analyzer.go
+++ b/internal/gpt/analyzer.go
@@ -20,6 +20,7 @@ import (
 type Analyzer struct {
 	context   context.Context
 	gptClient *gogpt.Client
+	gptModel  string
 }
 
 type Result struct {
@@ -28,10 +29,11 @@ type Result struct {
 	GPTResult  string
 }
 
-func NewAnalyzer(ctx context.Context, gptToken string) *Analyzer {
+func NewAnalyzer(ctx context.Context, gptToken string, gptModel string) *Analyzer {
 	return &Analyzer{
 		context:   ctx,
 		gptClient: gogpt.NewClient(gptToken),
+		gptModel:  gptModel,
 	}
 }
 
@@ -109,7 +111,7 @@ func (a *Analyzer) Analyze(dataChannel <-chan collectors.CollectedData) chan Res
 				prompt := generatePrompt(raw, entityType)
 
 				requestOptions := gogpt.CompletionRequest{
-					Model:  gogpt.GPT3TextDavinci003,
+					Model:  a.gptModel,
 					Prompt: prompt,
 					// Temperature sets how much freedom GPT-3 API has to introduce randomness in the response
 					// 1.0 means maximum freedom


### PR DESCRIPTION
#### What's being changed?
Added an option to control the GPT model being used in the GPT analysis. Default is still GPT3.5.

#### Check off the following:

- [x] This PR follows the CONTRIBUTION.md guidelines
- [x] I have self-reviewed my changes before submitting the PR
