### PR TITLE
fix: Add pagination to collaborators collector

### DIFF
--- a/internal/collectors/github/repository_collector.go
+++ b/internal/collectors/github/repository_collector.go
@@ -360,7 +360,7 @@ func (rc *repositoryCollector) withVulnerabilityAlerts(repo ghcollected.Reposito
 }
 
 func (rc *repositoryCollector) withRepoCollaborators(repo ghcollected.Repository, org string) ghcollected.Repository {
-	users, _, err := rc.Client.Client().Repositories.ListCollaborators(rc.Context, org, repo.Repository.Name, &github.ListCollaboratorsOptions{})
+	users, err := pagination.New[*github.User](rc.Client.Client().Repositories.ListCollaborators, &github.ListCollaboratorsOptions{}).Sync(rc.Context, org, repo.Repository.Name)
 	if err != nil {
 		perm := collectors.NewMissingPermission(permissions.RepoAdmin, collectors.FullRepoName(org, repo.Repository.Name),
 			"Cannot read repository collaborators", namespace.Repository)
@@ -368,7 +368,7 @@ func (rc *repositoryCollector) withRepoCollaborators(repo ghcollected.Repository
 		return repo
 	}
 
-	repo.Collaborators = users
+	repo.Collaborators = users.Collected
 	return repo
 }
 

--- a/policies/github/repository.rego
+++ b/policies/github/repository.rego
@@ -151,7 +151,7 @@ missing_default_branch_protection_deletion := false {
 missing_default_branch_protection_deletion := false {
     some index
     rule := input.rules_set[index]
-    rule.type == "deletions"
+    rule.type == "deletion"
 }
 
 # METADATA


### PR DESCRIPTION
<!--
Thank you for contributing to this project! Please fill out the information below to help us review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can best triage your pull request.

See our [CONTRIBUTING.md](/main/CONTRIBUTING.md) for information on how to contribute.

Thanks again!
-->

#### What's being changed?
<!-- Consider sharing artifacts of the changes, such as code snippets, GIFs or screenshots; whatever shares the most context. -->
1. Added pagination to repository collaborators collector. Without it, it only returns 30 collaborators as it's a default per page.
2. Fixed typo in deletion protection rule check for repository rulesets. See [documentation](https://docs.github.com/en/rest/repos/rules?apiVersion=2022-11-28#get-rules-for-a-branch). 

#### Is this PR related to an existing issue?
<!--
- If there's an existing issue for your change, please link to it.
- If there's _no_ existing issue, please consider opening one first: https://github.com/legit-labs/legitify/issues/new/choose. -->

#### Check off the following:

- [x] This PR follows the CONTRIBUTION.md guidelines
- [x] I have self-reviewed my changes before submitting the PR
