### PR TITLE
docs: multiple repos separated by comma note

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -12,7 +12,7 @@ inputs:
     required: false
     default: "false"
   repositories:
-    description: "Strings of owner/repo seperated by a comma. If this is set, only selected repositories will be analyzed"
+    description: "Strings of owner/repo separated by a comma. If this is set, only selected repositories will be analyzed"
     required: false
   legitify_base_version:
     description: "The base version of legitify to use. Non breaking changes will be auto updated."
@@ -35,7 +35,7 @@ inputs:
     required: false
     default: "legitify-report"
   ignore-policies:
-    description: "List of policies to ignore (SKIP). Policies should be seperated by a new line"
+    description: "List of policies to ignore (SKIP). Policies should be separated by a new line"
     required: false
     default: ""
   extra:

--- a/action.yml
+++ b/action.yml
@@ -12,7 +12,7 @@ inputs:
     required: false
     default: "false"
   repositories:
-    description: "Strings of owner/repo. If this is set, only selected repositories will be analyzed"
+    description: "Strings of owner/repo seperated by a comma. If this is set, only selected repositories will be analyzed"
     required: false
   legitify_base_version:
     description: "The base version of legitify to use. Non breaking changes will be auto updated."

--- a/action_examples/analyze_repos.yml
+++ b/action_examples/analyze_repos.yml
@@ -16,4 +16,4 @@ jobs:
         uses: Legit-Labs/legitify@main # it is recommended to use a specific commit hash
         with:
           github_token: ${{ secrets.PAT_FOR_LEGITIFY }}
-          repositories: owner1/repo1 owner1/repo2
+          repositories: owner1/repo1, owner1/repo2


### PR DESCRIPTION

#### What's being changed?

Updating docs and action examples to note that one must separate multiple repos with commas. 

#### Is this PR related to an existing issue?
no

#### Check off the following:

- [x] This PR follows the CONTRIBUTION.md guidelines
- [x] I have self-reviewed my changes before submitting the PR
