### PR TITLE
feat:  Add policy for detecting GitHub Secret-Scanning

### DIFF
--- a/e2e/github_repository.go
+++ b/e2e/github_repository.go
@@ -78,7 +78,7 @@ var testCasesGitHubRepository = []testCase{
 	},
 	{
 		path:         "data.repository.secret_scanning_not_enabled",
-		failedEntity: "bad_repo",
-		passedEntity: "good-public-repo",
+		failedEntity: "bad_public_repo",
+		passedEntity: "good_public_repo",
 	},
 }

--- a/e2e/github_repository.go
+++ b/e2e/github_repository.go
@@ -76,4 +76,9 @@ var testCasesGitHubRepository = []testCase{
 		failedEntity: "bad_repo",
 		passedEntity: "good_repo",
 	},
+	{
+		path:         "data.repository.secret_scanning_not_enabled",
+		failedEntity: "bad_repo",
+		passedEntity: "good-public-repo",
+	},
 }

--- a/internal/analyzers/skippers/skippers.go
+++ b/internal/analyzers/skippers/skippers.go
@@ -39,13 +39,13 @@ func NewSkipper(ctx context.Context) Skipper {
 			"enterprise": func(_ collectors.CollectedData) bool {
 				return !context_utils.GetIsCloud(ctx)
 			},
-			"is_branch_protection_supported": func(data collectors.CollectedData) bool {
+			"advanced_security": func(data collectors.CollectedData) bool {
 				repositoryContext, ok := data.Context.(collectors.CollectedDataRepositoryContext)
 				if !ok {
 					log.Printf("invalid type %T", data.Context)
 					return false
 				}
-				return repositoryContext.IsBranchProtectionSupported()
+				return repositoryContext.HasGithubAdvancedSecurity()
 			},
 		},
 	}

--- a/internal/analyzers/skippers/skippers.go
+++ b/internal/analyzers/skippers/skippers.go
@@ -39,6 +39,14 @@ func NewSkipper(ctx context.Context) Skipper {
 			"enterprise": func(_ collectors.CollectedData) bool {
 				return !context_utils.GetIsCloud(ctx)
 			},
+			"is_branch_protection_supported": func(data collectors.CollectedData) bool {
+				repositoryContext, ok := data.Context.(collectors.CollectedDataRepositoryContext)
+				if !ok {
+					log.Printf("invalid type %T", data.Context)
+					return false
+				}
+				return repositoryContext.IsBranchProtectionSupported()
+			},
 		},
 	}
 }

--- a/internal/clients/github/client.go
+++ b/internal/clients/github/client.go
@@ -4,6 +4,12 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"log"
+	"net/http"
+	"regexp"
+	"strings"
+	"sync"
+
 	"github.com/Legit-Labs/legitify/internal/clients/github/pagination"
 	"github.com/Legit-Labs/legitify/internal/clients/github/transport"
 	"github.com/Legit-Labs/legitify/internal/clients/github/types"
@@ -12,11 +18,6 @@ import (
 	"github.com/Legit-Labs/legitify/internal/common/slice_utils"
 	commontypes "github.com/Legit-Labs/legitify/internal/common/types"
 	"github.com/Legit-Labs/legitify/internal/screen"
-	"log"
-	"net/http"
-	"regexp"
-	"strings"
-	"sync"
 
 	githubcollected "github.com/Legit-Labs/legitify/internal/collected/github"
 	"github.com/Legit-Labs/legitify/internal/common/permissions"
@@ -655,4 +656,17 @@ func (c *Client) GetOrganizationSecrets(org string) (*gh.Secrets, error) {
 		return nil, fmt.Errorf("unexpected HTTP status: %d", res.StatusCode)
 	}
 	return secrets, nil
+}
+
+func (c *Client) GetSecurityAndAnalysisForRepository(repo, owner string) (*gh.SecurityAndAnalysis, error) {
+	r, res, err := c.Client().Repositories.Get(c.context, owner, repo)
+
+	if err != nil {
+		return nil, err
+	}
+	if res.StatusCode != 200 {
+		return nil, fmt.Errorf("unexpected HTTP status: %d", res.StatusCode)
+	}
+
+	return r.SecurityAndAnalysis, nil
 }

--- a/internal/collected/github/repository.go
+++ b/internal/collected/github/repository.go
@@ -72,6 +72,7 @@ type Repository struct {
 	DependencyGraphManifests     *GitHubQLDependencyGraphManifests `json:"dependency_graph_manifests"`
 	RulesSet                     []*types.RepositoryRule           `json:"rules_set,omitempty"`
 	RepoSecrets                  []*RepositorySecret               `json:"repository_secrets,omitempty"`
+	SecurityAndAnalysis          *github.SecurityAndAnalysis       `json:"security_and_analysis,omitempty"`
 }
 
 type RepositorySecret struct {

--- a/internal/collectors/collector.go
+++ b/internal/collectors/collector.go
@@ -15,7 +15,7 @@ type CollectedDataContext interface {
 type CollectedDataRepositoryContext interface {
 	CollectedDataContext
 	HasBranchProtectionPermission() bool
-	IsBranchProtectionSupported() bool
+	HasGithubAdvancedSecurity()     bool
 }
 
 type CollectedData struct {

--- a/internal/collectors/collector.go
+++ b/internal/collectors/collector.go
@@ -15,6 +15,7 @@ type CollectedDataContext interface {
 type CollectedDataRepositoryContext interface {
 	CollectedDataContext
 	HasBranchProtectionPermission() bool
+	IsBranchProtectionSupported() bool
 }
 
 type CollectedData struct {

--- a/internal/collectors/github/repository_collector.go
+++ b/internal/collectors/github/repository_collector.go
@@ -469,7 +469,6 @@ func (rc *repositoryCollector) checkMissingPermissions(repo ghcollected.Reposito
 		missingPermissions = append(missingPermissions, perm)
 	}
 	if repo.SecurityAndAnalysis == nil {
-		//if (not org.owner and not scope.repo_admin) {
 		var effect string
 		if !checkRepoAdminPermission(repoContext.roles) {
 			effect = "Cannot read repository Security and Analysis settings"

--- a/internal/collectors/github/repository_collector.go
+++ b/internal/collectors/github/repository_collector.go
@@ -136,11 +136,11 @@ func (rc *repositoryCollector) collectSpecific(repositories []types.RepositoryWi
 
 					hasBp := hasBranchProtection(org, query.RepositoryOwner.Repository.IsPrivate)
 					collectionContext = newRepositoryContext([]permissions.Role{org.Role, query.RepositoryOwner.Repository.ViewerPermission},
-						hasBp, org.IsEnterprise(), false)
+						hasBp, org.IsEnterprise(), false, false)
 				} else {
 					hasBp := rc.hasBranchProtectionForUser(repo.Owner, query.RepositoryOwner.Repository.IsPrivate)
 					collectionContext = newRepositoryContext([]permissions.Role{query.RepositoryOwner.Repository.ViewerPermission},
-						hasBp, false, false)
+						hasBp, false, false, false)
 				}
 
 				rc.collectRepository(&query.RepositoryOwner.Repository, repo.Owner, collectionContext)
@@ -206,7 +206,7 @@ func (rc *repositoryCollector) collectRepositories(org *ghcollected.ExtendedOrg)
 				node := &(nodes[i])
 				extraGw.Do(func() {
 					collectionContext := newRepositoryContext([]permissions.Role{org.Role, node.ViewerPermission},
-						hasBranchProtection(org, node.IsPrivate), org.IsEnterprise(), false)
+						hasBranchProtection(org, node.IsPrivate), org.IsEnterprise(), false, false)
 					rc.collectRepository(node, org.Name(), collectionContext)
 				})
 			}
@@ -229,6 +229,7 @@ func (rc *repositoryCollector) collectRepository(repository *ghcollected.GitHubQ
 	missingPermissions := rc.checkMissingPermissions(repo, entityName)
 	rc.IssueMissingPermissions(missingPermissions...)
 	collectionContext.SetHasBranchProtectionPermission(!repo.NoBranchProtectionPermission)
+	collectionContext.SetHasGithubAdvancedSecurity(repo.SecurityAndAnalysis != nil)
 	rc.CollectDataWithContext(repo, repo.Repository.Url, collectionContext)
 	rc.CollectionChangeByOne()
 }

--- a/internal/collectors/github/repository_context.go
+++ b/internal/collectors/github/repository_context.go
@@ -9,6 +9,7 @@ type repositoryContext struct {
 	isEnterprise                  bool
 	isBranchProtectionSupported   bool
 	hasBranchProtectionPermission bool
+	hasGithubAdvancedSecurity     bool
 }
 
 func (rc *repositoryContext) Premium() bool {
@@ -31,11 +32,20 @@ func (rc *repositoryContext) HasBranchProtectionPermission() bool {
 	return rc.hasBranchProtectionPermission
 }
 
-func newRepositoryContext(roles []permissions.RepositoryRole, isBranchProtectionSupported bool, isEnterprise bool, hasBranchProtectionPermission bool) *repositoryContext {
+func (rc *repositoryContext) SetHasGithubAdvancedSecurity(value bool) {
+	rc.hasGithubAdvancedSecurity = value
+}
+
+func (rc *repositoryContext) HasGithubAdvancedSecurity() bool {
+	return rc.hasGithubAdvancedSecurity
+}
+
+func newRepositoryContext(roles []permissions.RepositoryRole, isBranchProtectionSupported bool, isEnterprise bool, hasBranchProtectionPermission bool, hasGithubAdvancedSecurity bool) *repositoryContext {
 	return &repositoryContext{
 		roles:                         roles,
 		isEnterprise:                  isEnterprise,
 		isBranchProtectionSupported:   isBranchProtectionSupported,
 		hasBranchProtectionPermission: hasBranchProtectionPermission,
+		hasGithubAdvancedSecurity:     hasGithubAdvancedSecurity,
 	}
 }

--- a/policies/github/repository.rego
+++ b/policies/github/repository.rego
@@ -721,7 +721,7 @@ repository_secret_is_stale[stale] := true{
 # METADATA
 # scope: rule
 # title: Secret Scanning should be enabled
-# description: Repositories should not have secrets hard-coded in the files. It is recommended to enable some sort of secret scanning.
+# description: Repository should have secret scanning enabled. Secret scanning helps prevent the exposure of sensitive information and ensures compliance.
 # custom:
 #   remediationSteps:
 #     - 1. Go to the repository settings page

--- a/policies/github/repository.rego
+++ b/policies/github/repository.rego
@@ -729,7 +729,7 @@ repository_secret_is_stale[stale] := true{
 #     - 3. Under 'Secret scanning', click 'Enable'
 #   severity: MEDIUM
 #   requiredScopes: [repo]
-#   prerequisites: [is_branch_protection_supported]
+#   prerequisites: [advanced_security]
 #   threat: Exposed secrets increases the risk of sensitive information such as API keys, passwords, and tokens being disclosed, leading to unauthorized access to systems and services, and data breaches.
 default secret_scanning_not_enabled := true
 

--- a/policies/github/repository.rego
+++ b/policies/github/repository.rego
@@ -717,3 +717,22 @@ repository_secret_is_stale[stale] := true{
     }
 
 }
+
+# METADATA
+# scope: rule
+# title: Secret Scanning should be enabled for public repositories
+# description: Public repositories should not have secrets hard-coded in the files. It is recommended to enable some sort of secret scanning.
+# custom:
+#   remediationSteps:
+#     - 1. Go to the repository settings page
+#     - 2. Under the 'Security' title on the left, select 'Code security and analysis'
+#     - 3. Under 'Secret scanning', click 'Enable'
+#   severity: MEDIUM
+#   requiredScopes: [repo]
+#   prerequisites: [is_branch_protection_supported]
+#   threat: Exposed secrets increases the risk of sensitive information such as API keys, passwords, and tokens being disclosed, leading to unauthorized access to systems and services, and data breaches.
+default secret_scanning_not_enabled := true
+
+secret_scanning_not_enabled := false{
+    input.security_and_analysis.secret_scanning.status == "enabled"
+}

--- a/policies/github/repository.rego
+++ b/policies/github/repository.rego
@@ -720,8 +720,8 @@ repository_secret_is_stale[stale] := true{
 
 # METADATA
 # scope: rule
-# title: Secret Scanning should be enabled for public repositories
-# description: Public repositories should not have secrets hard-coded in the files. It is recommended to enable some sort of secret scanning.
+# title: Secret Scanning should be enabled
+# description: Repositories should not have secrets hard-coded in the files. It is recommended to enable some sort of secret scanning.
 # custom:
 #   remediationSteps:
 #     - 1. Go to the repository settings page

--- a/test/repository_test.go
+++ b/test/repository_test.go
@@ -371,6 +371,28 @@ func TestRepositoryWithNoSecrets(t *testing.T) {
 	repositoryTestTemplate(t, name, makeMockData(), testedPolicyName, expectFailure, scm_type.GitHub)
 }
 
+func TestRepositorySecretScanning(t *testing.T) {
+	name := "repository secret scanning is disabled"
+	testedPolicyName := "secret_scanning_not_enabled"
+	makeMockData := func(flag string) githubcollected.Repository {
+		return githubcollected.Repository{
+			SecurityAndAnalysis: &github.SecurityAndAnalysis{
+				SecretScanning: &github.SecretScanning{Status: &flag},
+			},
+		}
+	}
+
+	options := map[bool]string{
+		false: "enabled",
+		true:  "disabled",
+	}
+
+	for _, expectFailure := range bools {
+		flag := options[expectFailure]
+		repositoryTestTemplate(t, name, makeMockData(flag), testedPolicyName, expectFailure, scm_type.GitHub)
+	}
+}
+
 func TestGitlabRepositoryTooManyAdmins(t *testing.T) {
 	name := "Project Has Too Many Owners"
 	testedPolicyName := "project_has_too_many_admins"


### PR DESCRIPTION
* Add collection of 'Security and Analysis' settings for github repos

<!--
Thank you for contributing to this project! Please fill out the information below to help us review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can best triage your pull request.

See our [CONTRIBUTING.md](/main/CONTRIBUTING.md) for information on how to contribute.

Thanks again!
-->

#### What's being changed?
<!-- Consider sharing artifacts of the changes, such as code snippets, GIFs or screenshots; whatever shares the most context. -->

#### Is this PR related to an existing issue?
<!--
- If there's an existing issue for your change, please link to it.
- If there's _no_ existing issue, please consider opening one first: https://github.com/legit-labs/legitify/issues/new/choose. -->

#### Check off the following:

- [x] This PR follows the CONTRIBUTION.md guidelines
- [x] I have self-reviewed my changes before submitting the PR
