### PR TITLE
fix: Update action file to resolve warnings and upcoming deprecations

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -69,7 +69,7 @@ runs:
       shell: bash
       run: |
         echo "${{ inputs.ignore-policies }}" > "${GITHUB_ACTION_PATH}/ignored-policies"
-    - uses: actions/setup-node@v3
+    - uses: actions/setup-node@v4
       with:
           node-version: '20'
 

--- a/action.yml
+++ b/action.yml
@@ -71,7 +71,7 @@ runs:
         echo "${{ inputs.ignore-policies }}" > "${GITHUB_ACTION_PATH}/ignored-policies"
     - uses: actions/setup-node@v3
       with:
-          node-version: '16'
+          node-version: '20'
 
     - id: analyze
       shell: bash
@@ -95,13 +95,13 @@ runs:
     - name: "Upload SARIF as Code Scanning Results"
       if: ${{ inputs.upload_code_scanning == 'true' }}
       continue-on-error: true
-      uses: github/codeql-action/upload-sarif@v2
+      uses: github/codeql-action/upload-sarif@v3
       with:
         sarif_file: legitify-output.sarif
         category: "legitify-report"
     - name: "Upload outputs as Workflow Artifacts"
       if: ${{ steps.analyze.outputs.is_private == 'true' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ inputs.artifact_name }}
         path: legitify-output.*


### PR DESCRIPTION
<!--
Thank you for contributing to this project! Please fill out the information below to help us review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can best triage your pull request.

See our [CONTRIBUTING.md](/main/CONTRIBUTING.md) for information on how to contribute.

Thanks again!
-->

#### What's being changed?
Update the `action.yml` to resolve warnings around deprecated actions:

* Update node to use node 20 instead of node 16 (GitHub forces node 20 anyways)
   * Update the setup-node action to v4
* Update `upload-sarif` action to v3 (v2 is being deprecated in December)
* Update `upload-artifact` action to v4 (v3 is being deprecated in November)

#### Is this PR related to an existing issue?
No - this is just maintenance that I noticed needs to be done to resolve warnings.

#### Check off the following:

- [X] This PR follows the CONTRIBUTION.md guidelines
- [X] I have self-reviewed my changes before submitting the PR
